### PR TITLE
add check to see if a name parameter was passed to create-settlement command

### DIFF
--- a/modules/towns/commands.dsc
+++ b/modules/towns/commands.dsc
@@ -25,6 +25,10 @@ cc_towns_create_c:
     name: create-settlement
     usage: /create-settlement <&lt>name<&gt>
     script:
+        - if <context.args.size> < 1:
+            - narrate "<red>Sorry, you need to specify a name for your settlement."
+            - narrate "Usage: <yellow>/create-settlement <&lt>name<&gt><reset>"
+            - stop
         - ~webget https://clovercraft.gg/api/settlements/create?denizenkey=mydenizensecret&uuid=<player.uuid>&name=<context.args.get[1]> save:created
         - if <entry[created].status> == 200:
             - ~yaml loadtext:<entry[created].result> id:created


### PR DESCRIPTION
- prevents invalid settlement names from requested from the server
- fixes clovercraft/denizen#4